### PR TITLE
fix/sort-comments

### DIFF
--- a/apps/frontend/hooks/useRaidList.ts
+++ b/apps/frontend/hooks/useRaidList.ts
@@ -53,7 +53,7 @@ const orderBy = (raidSortKey: raidSortKeys) => ({
   ...(raidSortKey === 'oldestComment' && {
     updates_aggregate: {
       min: {
-        created_at: 'asc_nulls_last',
+        created_at: 'asc_nulls_first',
       },
     },
   }),


### PR DESCRIPTION
## Overview

- Resolves #61 
- Uses the `updates_aggregate` 
- Some specifics that we can change:
  - Oldest Comment places the nulls _first_ and then the comments. Reasoning being that Raids w/o comments are a priority to surface when sorting with this intention. We can change this behavior by changing `  created_at: 'asc_nulls_first', ` to `  created_at: 'asc_nulls_last',` but it seems reasonable to surface Raids needing attention (no comments added)
  - Newest Comment is the opposite -- surfaces comments _first_ and then nulls
- Recently updated may need some attention here -- this shows Raids that have been updated but doesn't seem to include comments. Leaving this unchanged for now

## Screencap

https://user-images.githubusercontent.com/9438776/218646954-63792f5c-67b7-4ca2-8085-7f7505c0a4b9.mp4
