### PR TITLE
Add events for initial DM bot notifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,16 +48,23 @@ services:
       # HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET}
       ## uncomment next line for JWT configuration (NextAuth)
       # HASURA_GRAPHQL_JWT_SECRET: ${HASURA_GRAPHQL_JWT_SECRET}
+      HASURA_EVENT_WEBHOOK_SECRET: ${HASURA_EVENT_WEBHOOK_SECRET}
+      HASURA_EVENT_WEBHOOK_URL: ${HASURA_EVENT_WEBHOOK_URL}
 
   hasura-setup:
     container_name: dm_hasura_setup
     image: alpine:latest
     depends_on:
       - graphql-engine
-    restart: "no"
+    restart: 'no'
     volumes:
       - ./services/hasura:/usr/local/hasura
-    entrypoint: ["/bin/sh", "-c", "cd /usr/local/hasura && chmod +x ./setup.sh && ./setup.sh"]
+    entrypoint:
+      [
+        '/bin/sh',
+        '-c',
+        'cd /usr/local/hasura && chmod +x ./setup.sh && ./setup.sh',
+      ]
     environment:
       HASURA_GRAPHQL_ENDPOINT: http://graphql-engine:${HASURA_ENDPOINT_PORT}
       ## uncomment next line to set an admin secret

--- a/services/hasura/metadata/databases/default/tables/public_raid_parties.yaml
+++ b/services/hasura/metadata/databases/default/tables/public_raid_parties.yaml
@@ -57,3 +57,27 @@ delete_permissions:
   - role: member
     permission:
       filter: {}
+event_triggers:
+  - name: raider_added
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_EVENT_WEBHOOK_URL}}/hasura/cleric-added'
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENT_WEBHOOK_SECRET
+    request_transform:
+      body:
+        action: transform
+        template: |-
+          {
+            "member_id": {{$body.event.data.new.member_id}},
+            "raid_id": {{$body.event.data.new.raid_id}}
+          }
+      template_engine: Kriti
+      version: 2

--- a/services/hasura/metadata/databases/default/tables/public_raids.yaml
+++ b/services/hasura/metadata/databases/default/tables/public_raids.yaml
@@ -142,3 +142,79 @@ update_permissions:
         - v1_id
       filter: {}
       check: null
+event_triggers:
+  - name: cleric_added
+    definition:
+      enable_manual: false
+      update:
+        columns:
+          - raid_channel_id
+          - cleric_id
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_EVENT_WEBHOOK_URL}}/hasura/cleric-added'
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENT_WEBHOOK_SECRET
+    request_transform:
+      body:
+        action: transform
+        template: |-
+          {
+            "cleric_id": {{$body.event.data.new.cleric_id}},
+            "raid_channel_id": {{$body.event.data.new.raid_channel_id}}
+          }
+      template_engine: Kriti
+      version: 2
+  - name: create_raid_channels
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_EVENT_WEBHOOK_URL}}/hasura/cleric-added'
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENT_WEBHOOK_SECRET
+    request_transform:
+      body:
+        action: transform
+        template: |-
+          {
+            "name": {{$body.event.data.new.name}},
+            "id": {{$body.event.data.new.id}}
+          }
+      template_engine: Kriti
+      version: 2
+  - name: status_updated
+    definition:
+      enable_manual: false
+      update:
+        columns:
+          - status_key
+          - raid_channel_id
+          - id
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_EVENT_WEBHOOK_URL}}/hasura/cleric-added'
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENT_WEBHOOK_SECRET
+    request_transform:
+      body:
+        action: transform
+        template: |-
+          {
+            "id": {{$body.event.data.new.id}},
+            "status_key": {{$body.event.data.new.status_key}},
+            "raid_channel_id": {{$body.event.data.new.raid_channel_id}}
+          }
+      template_engine: Kriti
+      version: 2

--- a/services/hasura/metadata/databases/default/tables/public_raids_roles_required.yaml
+++ b/services/hasura/metadata/databases/default/tables/public_raids_roles_required.yaml
@@ -45,3 +45,27 @@ delete_permissions:
   - role: member
     permission:
       filter: {}
+event_triggers:
+  - name: role_added
+    definition:
+      enable_manual: false
+      insert:
+        columns: '*'
+    retry_conf:
+      interval_sec: 10
+      num_retries: 0
+      timeout_sec: 60
+    webhook: '{{HASURA_EVENT_WEBHOOK_URL}}/hasura/role-added'
+    headers:
+      - name: Authorization
+        value_from_env: HASURA_EVENT_WEBHOOK_SECRET
+    request_transform:
+      body:
+        action: transform
+        template: |-
+          {
+            "role": {{$body.event.data.new.role}},
+            "raid_id": {{$body.event.data.new.raid_id}}
+          }
+      template_engine: Kriti
+      version: 2


### PR DESCRIPTION
Adds events for bot notifications:
- `role_added` for notifying in #who-is-available that a role is required for a raid
- `cleric_added` for notifying that a cleric was added to the raid
- `create_raid_channels` for creating an internal and external Discord channel when a raid is created
- `status_updated` for posting to the raid channel an updated raid status
- `raider_added` for posting to the raid channel when someone is added to a raid