### PR TITLE
fix: consultation view (caused by null raid id)

### DIFF
--- a/apps/frontend/components/RaidDetailsCard.tsx
+++ b/apps/frontend/components/RaidDetailsCard.tsx
@@ -260,8 +260,8 @@ const RaidDetailsCard = ({ raid, consultation }: RaidProps) => {
             ? _.get(raid, 'invoiceAddress')
             : undefined,
           link: _.get(raid, 'invoiceAddress')
-            ? `/escrow/${raid.id}`
-            : `/escrow/new?raidId=${raid.id}`,
+            ? `/escrow/${raid?.id}`
+            : `/escrow/new${raid?.id ? `?raidId=${raid?.id}` : ''}`,
         },
       ]),
     },


### PR DESCRIPTION
works fine on development-> https://dm-develop.up.railway.app/consultations/221cbb67-bcfd-4335-9e0d-a5e53c42f157


prod app crash link -> https://dm.raidguild.org/consultations/6a46aab0-1d2b-4d63-a7c4-8b340420aa19 (click on any consultation)