### PR TITLE
Update smart invoice subgraph versions

### DIFF
--- a/libs/escrow-utils/src/constants.ts
+++ b/libs/escrow-utils/src/constants.ts
@@ -88,7 +88,7 @@ export const NETWORK_CONFIG: { [key: number]: NetworkConfig } = {
     },
   },
   10: {
-    SUBGRAPH: 'smart-invoice-optimism/v0.0.1',
+    SUBGRAPH: 'smart-invoice-optimism/v0.0.2',
     WRAPPED_NATIVE_TOKEN: _.toLower(
       '0x4200000000000000000000000000000000000006'
     ) as Hex,
@@ -118,7 +118,7 @@ export const NETWORK_CONFIG: { [key: number]: NetworkConfig } = {
     },
   },
   100: {
-    SUBGRAPH: 'smart-invoice-gnosis/v0.0.1',
+    SUBGRAPH: 'smart-invoice-gnosis/v0.0.4',
     INVOICE_FACTORY: _.toLower(
       '0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8'
     ) as Hex,


### PR DESCRIPTION
- Updates gnosis subgraph to https://api.studio.thegraph.com/query/78711/smart-invoice-gnosis/v0.0.4
- Updates optimism subgraph to https://api.studio.thegraph.com/query/78711/smart-invoice-optimism/v0.0.2