### PR TITLE
Add user description textbox

### DIFF
--- a/apps/frontend/components/MemberDetailsCard.tsx
+++ b/apps/frontend/components/MemberDetailsCard.tsx
@@ -198,6 +198,7 @@ const MemberDetailsCard = ({
       >
         <UpdateMemberForm
           member={member}
+          introduction={application?.introduction}
           memberAddress={memberAddress}
           memberId={_.get(member, 'id')}
           memberReload={memberReload}

--- a/apps/frontend/components/MemberDetailsCard.tsx
+++ b/apps/frontend/components/MemberDetailsCard.tsx
@@ -285,10 +285,14 @@ const MemberDetailsCard = ({
             </Flex>
           ))}
 
-          {_.get(application, 'introduction') && (
+          {(_.get(member, 'description') ||
+            _.get(application, 'introduction')) && (
             <>
               <Divider color='gray.200' />
-              <Text size='md'>{_.get(application, 'introduction')}</Text>
+              <Text size='md'>
+                {_.get(member, 'description') ||
+                  _.get(application, 'introduction')}
+              </Text>
             </>
           )}
 

--- a/apps/frontend/components/MemberUpdateForm.tsx
+++ b/apps/frontend/components/MemberUpdateForm.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable dot-notation */
-import { Box, Button, Input, Select, Stack } from '@raidguild/design-system';
+import {
+  Box,
+  Button,
+  Input,
+  Select,
+  Stack,
+  Textarea,
+} from '@raidguild/design-system';
 import { useMemberUpdate } from '@raidguild/dm-hooks';
 import { IMember } from '@raidguild/dm-types';
 import {
@@ -14,6 +21,7 @@ import { useForm } from 'react-hook-form';
 
 interface UpdateMemberFormProps {
   member: IMember;
+  introduction?: string;
   memberAddress?: string;
   memberId?: string;
   memberReload?: () => void;
@@ -21,6 +29,7 @@ interface UpdateMemberFormProps {
 }
 const UpdateMemberForm = ({
   member,
+  introduction,
   memberAddress,
   memberId,
   memberReload,
@@ -106,6 +115,7 @@ const UpdateMemberForm = ({
       member_updates: {
         name: values.memberName ?? member.name,
         is_raiding: values?.isRaiding?.value ?? member?.isRaiding,
+        description: values.description ?? member?.description,
       },
       skills_updates: [...updatePrimarySkills, ...updateSecondarySkills],
       guild_classes_updates: updateGuildClasses,
@@ -247,6 +257,15 @@ const UpdateMemberForm = ({
                     ) || { value: false, label: 'Not Raiding' }) as any
                   }
                   options={IS_RAIDING_OPTIONS as any[]} // Option[]}
+                  localForm={localForm}
+                />
+
+                <Textarea
+                  name='description'
+                  defaultValue={member?.description || introduction || ''}
+                  aria-label='Enter your description'
+                  placeholder='Tell us about yourself'
+                  label='Member Description'
                   localForm={localForm}
                 />
 

--- a/libs/dm-graphql/src/fragments/members.ts
+++ b/libs/dm-graphql/src/fragments/members.ts
@@ -39,6 +39,7 @@ export const MEMBER_DETAIL_FRAGMENT = gql`
     name
     eth_address
     is_raiding
+    description
     ...MemberEnum
 
     contact_info {

--- a/libs/dm-types/src/members.ts
+++ b/libs/dm-types/src/members.ts
@@ -8,6 +8,7 @@ export interface IMember {
   id: string;
   name: string;
   isRaiding: boolean;
+  description?: string;
   skills: Skills[];
   membersGuildClasses: {
     guildClassKey: string;
@@ -48,6 +49,7 @@ export interface IMemberUpdate {
   member_updates?: {
     name?: string;
     is_raiding?: boolean;
+    description?: string;
   };
 
   skills_updates?: {

--- a/services/hasura/migrations/default/1724227996709_alter_table_public_members_add_column_description/down.sql
+++ b/services/hasura/migrations/default/1724227996709_alter_table_public_members_add_column_description/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.members DROP COLUMN description;
+

--- a/services/hasura/migrations/default/1724227996709_alter_table_public_members_add_column_description/up.sql
+++ b/services/hasura/migrations/default/1724227996709_alter_table_public_members_add_column_description/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.members ADD COLUMN description TEXT;


### PR DESCRIPTION
- set up migration for adding `description` field to member schema
- update types & hooks
- add textarea to the update member card
- display description with prio over introduction


https://github.com/user-attachments/assets/015217cf-91f2-4f70-9653-c51226d711bf

