### PR TITLE
fix: improve raid ID handling in escrow pages

### DIFF
--- a/apps/frontend/pages/escrow/index.tsx
+++ b/apps/frontend/pages/escrow/index.tsx
@@ -40,7 +40,7 @@ import SiteLayoutPublic from '../../components/SiteLayoutPublic';
 
 const ActionButtons = ({ chainId, raid }: { chainId: number; raid: IRaid }) => (
   <HStack>
-    {!raid && chainId !== 10 ? (
+    {!raid ? (
       <Link href='/escrow/new'>
         <Button variant='outline'>I don&apos;t have one</Button>
       </Link>
@@ -53,7 +53,7 @@ const ActionButtons = ({ chainId, raid }: { chainId: number; raid: IRaid }) => (
         >
           <Button
             variant='outline'
-            isDisabled={!raid || !!raid?.invoice?.invoiceAddress}
+            isDisabled={!raid?.id || !!raid?.invoice?.invoiceAddress}
           >
             Register Escrow
           </Button>
@@ -195,8 +195,8 @@ export const Escrow = () => {
                   <Stack>
                     <ActionButtons chainId={chainId} raid={raid} />
                     {raidId && !isLoading && (
-                      <Text color={raid ? 'green.500' : 'red.500'} mb='2'>
-                        {raid ? 'Raid ID is valid!' : 'Raid not found'}
+                      <Text color={raid?.id ? 'green.500' : 'red.500'} mb='2'>
+                        {raid?.id ? 'Raid ID is valid!' : 'Raid not found'}
                       </Text>
                     )}
                   </Stack>

--- a/apps/frontend/pages/escrow/new.tsx
+++ b/apps/frontend/pages/escrow/new.tsx
@@ -82,9 +82,13 @@ const NewEscrow = () => {
             </Text>
             <HStack justifyContent='center' w='100%'>
               <Button
-                onClick={() =>
-                  router.push(`/escrow/new?raidId=${raidId}&chainId=100`)
-                }
+                onClick={() => {
+                  if (raidId) {
+                    router.push(`/escrow/new?raidId=${raidId}&chainId=100`);
+                  } else {
+                    router.push(`/escrow/new?chainId=100`);
+                  }
+                }}
               >
                 <HStack spacing={2} align='center'>
                   <Image
@@ -96,9 +100,10 @@ const NewEscrow = () => {
                 </HStack>
               </Button>
               <Button
-                onClick={() =>
-                  router.push(`/escrow/new?raidId=${raidId}&chainId=10`)
-                }
+                onClick={() => {
+                  router.push(`/escrow/new?raidId=${raidId}&chainId=10`);
+                }}
+                isDisabled={!raidId}
               >
                 <HStack spacing={2} align='center'>
                   <Image


### PR DESCRIPTION
## Symmary
Only allow valid raid ids to be used for optimism and Gnosis by
1- Disable Register escrow if raid id is not valid
2- allow project based escrows only on Gnosis and disabled Optimism button if raid id is not valid
![image](https://github.com/user-attachments/assets/e0fefe27-f62e-4752-baf4-dad95b30ce62)
![image](https://github.com/user-attachments/assets/7bf3f884-93bb-4467-bddd-977aad0df197)


