### PR TITLE
Add link to RaidGuild Dune Dashboard

### DIFF
--- a/apps/frontend/pages/accounting.tsx
+++ b/apps/frontend/pages/accounting.tsx
@@ -3,11 +3,13 @@ import {
   Button,
   Flex,
   Heading,
+  Link,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
   Tabs,
+  Text,
 } from '@raidguild/design-system';
 import {
   useMemberList,
@@ -19,8 +21,8 @@ import { useSession } from 'next-auth/react';
 import { NextSeo } from 'next-seo';
 import Papa from 'papaparse';
 import { useCallback } from 'react';
-
 import _ from 'lodash';
+
 import BalancesTable from '../components/BalancesTable';
 import SiteLayout from '../components/SiteLayout';
 import SpoilsTable from '../components/SpoilsTable';
@@ -139,6 +141,22 @@ export const Accounting = () => {
         emptyDataPhrase='No transactions'
         error={error && isError}
       >
+        <Text>
+          View Dune Dashboard metrics{' '}
+          <Link
+            color='red.500'
+            href='https://dune.com/sunsakis/raidguild'
+            rel='noreferrer noopener'
+            target='_blank'
+            _hover={{
+              color: 'red.300',
+              textDecoration: 'underline',
+            }}
+          >
+            here
+          </Link>
+          .
+        </Text>
         <Tabs align='center' colorScheme='whiteAlpha' variant='soft-rounded'>
           <TabList>
             <Tab>


### PR DESCRIPTION
- Adds this (https://dune.com/sunsakis/raidguild) link to Accounting page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Accounting page with a clear message directing users to external dashboard metrics.
  - Integrated an interactive link with distinct styling and hover effects to facilitate easy navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->