### PR TITLE
Make sure apprentice intro renders on member card

### DIFF
--- a/apps/frontend/components/MemberCard.tsx
+++ b/apps/frontend/components/MemberCard.tsx
@@ -210,7 +210,7 @@ const MemberCard = ({ application, member }: MemberProps) => {
           <Stack spacing={4}>
             <Divider paddingTop={2} width='100%' alignSelf='center' />
             <Text size='md' maxW='900px'>
-              {_.truncate(_.get(application, 'description'), { length: 250 }) ??
+              {_.truncate(_.get(application, 'description'), { length: 250 }) ||
                 _.truncate(_.get(application, 'introduction'), { length: 250 })}
             </Text>
           </Stack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the member card display so that when a primary description isn’t provided, the introduction text appears instead. This adjustment results in a more consistent and complete view of member details for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->